### PR TITLE
fix number of elements in a row

### DIFF
--- a/src/vec2d.rs
+++ b/src/vec2d.rs
@@ -13,7 +13,7 @@ impl<T> Grid<T> {
     {
         let mut array = Vec::with_capacity(height);
         for _ in 0..height {
-            array.push([T::default()].repeat(width * height));
+            array.push([T::default()].repeat(width));
         }
         Self {
             array,


### PR DESCRIPTION
I'm reading your blog post (https://blog.adamchalmers.com/grids-1/) which contains this same code, and I'm pretty sure it is not correct to allocate the full `width * height` for `height` times.

This may have implications also for your criterion benchmarks...

Also, why not use `vec![T::default(); width]`?