### PR TITLE
Make vec2d.rs parallel for each element instead of just each column

### DIFF
--- a/src/vec2d.rs
+++ b/src/vec2d.rs
@@ -43,7 +43,7 @@ impl<T> Gridlike<T> for Grid<T> {
     {
         use rayon::prelude::*;
         self.array.par_iter_mut().enumerate().for_each(|(y, row)| {
-            for (x, item) in row.iter_mut().enumerate() {
+            for (x, item) in row.par_iter_mut().enumerate() {
                 *item = setter(Point { x, y });
             }
         });


### PR DESCRIPTION
This changes the amount of concurrency in vec2d to match that of vec1d, IIUC. Again benchmarks may be affected.